### PR TITLE
MPI Build Fix for newer GNU Fortran compiler versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume realloc_lhs -fp-model precise -fp-speculation strict")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qopt-report=0 -ip  -qopenmp -fPIC -xHost")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g")
+elseif ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+  Message(STATUS "Using GNU compiler")
+  # hardcoded gnu flags
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
 endif ()
 
 # Specify sources


### PR DESCRIPTION
@sriram-LANL 

Add `-fallow-argument-mismatch` to GNU fortran compiler flags to allow MPI calls to build with warnings on newer GNU compilers

https://stackoverflow.com/questions/63892055/fortran-error-type-mismatch-between-two-unrelated-subroutine-calls